### PR TITLE
Migrate to androidx (#65) (#66)

### DIFF
--- a/apk/build.gradle
+++ b/apk/build.gradle
@@ -6,6 +6,7 @@ android {
     }
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+
     defaultConfig {
         applicationId "com.austindroids.austinfeedsme"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -13,7 +14,7 @@ android {
         versionCode 1026
         versionName "1.7"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
     buildTypes {

--- a/apk/src/main/AndroidManifest.xml
+++ b/apk/src/main/AndroidManifest.xml
@@ -7,14 +7,4 @@
         android:label="@string/app_label"
         android:supportsRtl="true"
         android:theme="@style/AppTheme" />
-
-    <!--<uses-feature-->
-        <!--android:name="android.hardware.location"-->
-        <!--android:required="false" />-->
-
-    <!--<uses-feature-->
-        <!--android:name="android.hardware.location.network"-->
-        <!--android:required="false" />-->
-
-    <!--<uses-feature android:glEsVersion="0x00020000" android:required="true" />-->
 </manifest>

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,7 +8,7 @@ props.load(new FileInputStream(file(project.property("austinfeedsme.properties")
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    buildToolsVersion '28.0.3'
     baseFeature true
 
     defaultConfig {
@@ -23,7 +23,7 @@ android {
         manifestPlaceholders = [google_maps_key: props['google_maps_key'],
                                 fabricApiKey: props['fabric']]
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -82,10 +82,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Support Libs
-    implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibraryVersion"
-    implementation "com.android.support:recyclerview-v7:$rootProject.ext.supportLibraryVersion"
-    implementation "com.android.support:cardview-v7:$rootProject.ext.supportLibraryVersion"
-    implementation "com.android.support:design:$rootProject.ext.supportLibraryVersion"
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha01'
 
     // Dagger 2
     implementation "com.google.dagger:dagger:$rootProject.ext.daggerVersion"
@@ -98,8 +98,8 @@ dependencies {
     implementation "com.google.firebase:firebase-firestore:$rootProject.ext.firestoreVersion"
     implementation "com.google.firebase:firebase-auth:$rootProject.ext.firebaseVersion"
     implementation "com.google.firebase:firebase-core:$rootProject.ext.firebaseVersion"
-    implementation 'com.google.firebase:firebase-messaging:17.0.0'
-    implementation 'com.firebaseui:firebase-ui-auth:4.0.1'
+    implementation 'com.google.firebase:firebase-messaging:17.3.4'
+    implementation 'com.firebaseui:firebase-ui-auth:4.2.1'
 
     // Needed for Authentication
     implementation "com.google.android.gms:play-services-auth:$rootProject.ext.playServicesVersion"
@@ -140,10 +140,10 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.8.1'
 
     // Espresso Dependencies
-    androidTestImplementation "com.android.support.test:runner:$rootProject.ext.testSupportVersion"
-    androidTestImplementation "com.android.support.test:rules:$rootProject.ext.testSupportVersion"
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:2.2.2', {
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.0', {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'
         exclude module: 'recyclerview-v7'

--- a/base/src/androidTest/java/com/austindroids/austinfeedsme/events/EventsActivityTest.java
+++ b/base/src/androidTest/java/com/austindroids/austinfeedsme/events/EventsActivityTest.java
@@ -1,8 +1,8 @@
 package com.austindroids.austinfeedsme.events;
 
-import android.support.test.espresso.contrib.DrawerActions;
-import android.support.test.rule.ActivityTestRule;
-import android.support.v7.widget.SearchView;
+import androidx.test.espresso.contrib.DrawerActions;
+import androidx.test.rule.ActivityTestRule;
+import androidx.appcompat.widget.SearchView;
 import android.view.KeyEvent;
 
 import com.austindroids.austinfeedsme.R;
@@ -10,14 +10,14 @@ import com.austindroids.austinfeedsme.R;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.pressKey;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.pressKey;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Created by darrankelinske on 5/4/16.

--- a/base/src/main/java/com/austindroids/austinfeedsme/common/events/EventsPresenter.java
+++ b/base/src/main/java/com/austindroids/austinfeedsme/common/events/EventsPresenter.java
@@ -1,6 +1,6 @@
 package com.austindroids.austinfeedsme.common.events;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.austindroids.austinfeedsme.common.utils.DateUtils;

--- a/base/src/main/java/com/austindroids/austinfeedsme/common/logging/CrashlyticsTree.kt
+++ b/base/src/main/java/com/austindroids/austinfeedsme/common/logging/CrashlyticsTree.kt
@@ -1,6 +1,6 @@
 package com.austindroids.austinfeedsme.common.logging
 
-import android.support.annotation.Nullable
+import androidx.annotation.Nullable
 import android.util.Log
 import com.crashlytics.android.Crashlytics
 import timber.log.Timber

--- a/base/src/main/java/com/austindroids/austinfeedsme/common/pushnotifications/MessagingService.java
+++ b/base/src/main/java/com/austindroids/austinfeedsme/common/pushnotifications/MessagingService.java
@@ -6,7 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.media.RingtoneManager;
 import android.net.Uri;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 
 import com.austindroids.austinfeedsme.R;

--- a/base/src/main/java/com/austindroids/austinfeedsme/data/firebase/FirebaseEventsDataSource.java
+++ b/base/src/main/java/com/austindroids/austinfeedsme/data/firebase/FirebaseEventsDataSource.java
@@ -1,6 +1,7 @@
 package com.austindroids.austinfeedsme.data.firebase;
 
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import com.austindroids.austinfeedsme.data.Event;
 import com.austindroids.austinfeedsme.data.EventsDataSource;

--- a/base/src/main/java/com/austindroids/austinfeedsme/events/EventsActivity.kt
+++ b/base/src/main/java/com/austindroids/austinfeedsme/events/EventsActivity.kt
@@ -1,6 +1,5 @@
 package com.austindroids.austinfeedsme.events
 
-import android.app.Activity
 import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
@@ -8,20 +7,22 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
-import android.support.design.widget.NavigationView
-import android.support.v4.view.GravityCompat
-import android.support.v4.view.MenuItemCompat
-import android.support.v4.widget.DrawerLayout
-import android.support.v4.widget.SwipeRefreshLayout
-import android.support.v7.app.ActionBarDrawerToggle
-import android.support.v7.widget.*
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.widget.PopupMenu
+import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.GravityCompat
+import androidx.core.view.MenuItemCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.austindroids.austinfeedsme.R
 import com.austindroids.austinfeedsme.common.base.BaseActivity
 import com.austindroids.austinfeedsme.common.events.EventsContract
@@ -30,6 +31,7 @@ import com.austindroids.austinfeedsme.data.Event
 import com.austindroids.austinfeedsme.eventsfilter.EventFilterActivity
 import com.austindroids.austinfeedsme.eventsmap.EventsMapActivity
 import com.firebase.ui.auth.AuthUI
+import com.google.android.material.navigation.NavigationView
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import java.util.*
@@ -50,7 +52,6 @@ class EventsActivity : BaseActivity(), EventsContract.View {
     private var searchViewForMenu: SearchView? = null
     private var eventListAdapter: EventsAdapter? = null
     private var eventItemListener: EventsAdapter.EventItemListener = getEventItemListener()
-    private lateinit var navigationEventsFilter: MenuItem
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,7 +65,6 @@ class EventsActivity : BaseActivity(), EventsContract.View {
         navigationView = findViewById(R.id.navigation_view_events)
 
         setupActionBar()
-        setupMenu()
         setupSwipeToRefresh()
         setupEventsList()
         setupNavigationDrawer(navigationView)
@@ -97,7 +97,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
         MenuItemCompat.setOnActionExpandListener(searchMenu,
                 object : MenuItemCompat.OnActionExpandListener {
                     override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
-                        eventsPresenter!!.loadEvents()
+                        eventsPresenter.loadEvents()
                         return true  // Return true to collapse action view
                     }
 
@@ -176,7 +176,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
 
     override fun setPizzaCount(count: Int) {
         // get menu from navigationView
-        val menu = navigationView!!.menu
+        val menu = navigationView.menu
         // find MenuItem you want to change
         val navigationPizzaEvents = menu.findItem(R.id.events_pizza)
         //Check if user logged in, change sign in/out button to correct text
@@ -185,7 +185,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
 
     override fun setTacoCount(count: Int) {
         // get menu from navigationView
-        val menu = navigationView!!.menu
+        val menu = navigationView.menu
         // find MenuItem you want to change
         val navigationPizzaEvents = menu.findItem(R.id.events_tacos)
         //Check if user logged in, change sign in/out button to correct text
@@ -194,7 +194,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
     }
 
     override fun setBeerCount(count: Int) {// get menu from navigationView
-        val menu = navigationView!!.menu
+        val menu = navigationView.menu
         // find MenuItem you want to change
         val navigationPizzaEvents = menu.findItem(R.id.events_beer)
         //Check if user logged in, change sign in/out button to correct text
@@ -203,7 +203,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
     }
 
     override fun setTotalCount(count: Int) {// get menu from navigationView
-        val menu = navigationView!!.menu
+        val menu = navigationView.menu
         // find MenuItem you want to change
         val navigationPizzaEvents = menu.findItem(R.id.events_list)
         //Check if user logged in, change sign in/out button to correct text
@@ -212,8 +212,8 @@ class EventsActivity : BaseActivity(), EventsContract.View {
     }
 
     override fun showNoEventsView() {
-        eventsRecyclerView!!.visibility = View.GONE
-        noEventsLinearLayout!!.visibility = View.VISIBLE
+        eventsRecyclerView.visibility = View.GONE
+        noEventsLinearLayout.visibility = View.VISIBLE
     }
 
     override fun showProgress() {
@@ -233,7 +233,7 @@ class EventsActivity : BaseActivity(), EventsContract.View {
     private fun handleIntent(intent: Intent) {
         if (Intent.ACTION_SEARCH == intent.action) {
             val query = intent.getStringExtra(SearchManager.QUERY)
-            eventsPresenter!!.searchEvents(query)
+            eventsPresenter.searchEvents(query)
         }
     }
 
@@ -281,11 +281,11 @@ class EventsActivity : BaseActivity(), EventsContract.View {
 
         popup.setOnMenuItemClickListener { item ->
             when (item.itemId) {
-                R.id.todays_events -> eventsPresenter!!.setFiltering(EventsFilterType.TODAYS_EVENTS)
-                R.id.this_weeks_events -> eventsPresenter!!.setFiltering(EventsFilterType.THIS_WEEKS_EVENTS)
-                else -> eventsPresenter!!.setFiltering(EventsFilterType.ALL_EVENTS)
+                R.id.todays_events -> eventsPresenter.setFiltering(EventsFilterType.TODAYS_EVENTS)
+                R.id.this_weeks_events -> eventsPresenter.setFiltering(EventsFilterType.THIS_WEEKS_EVENTS)
+                else -> eventsPresenter.setFiltering(EventsFilterType.ALL_EVENTS)
             }
-            eventsPresenter!!.loadEvents()
+            eventsPresenter.loadEvents()
             true
         }
 
@@ -319,22 +319,10 @@ class EventsActivity : BaseActivity(), EventsContract.View {
         }
     }
 
-    private fun setupMenu() {
-        // get menu from navigationView
-        val menu = navigationView.menu
-
-        // find MenuItem you want to change
-        navigationEventsFilter = menu.findItem(R.id.events_filter)
-
-        //Check if user logged in, change sign in/out button to correct text
-
-        navigationEventsFilter.isVisible = FirebaseAuth.getInstance().currentUser != null
-    }
-
     override fun showEvents(events: List<Event>) {
         eventListAdapter!!.replaceData(events)
-        eventsRecyclerView!!.visibility = View.VISIBLE
-        noEventsLinearLayout!!.visibility = View.GONE
+        eventsRecyclerView.visibility = View.VISIBLE
+        noEventsLinearLayout.visibility = View.GONE
     }
 
     private fun setupSwipeToRefresh() {

--- a/base/src/main/java/com/austindroids/austinfeedsme/events/EventsAdapter.kt
+++ b/base/src/main/java/com/austindroids/austinfeedsme/events/EventsAdapter.kt
@@ -3,7 +3,7 @@ package com.austindroids.austinfeedsme.events
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.text.Html
 import android.text.Spanned
 import android.view.LayoutInflater

--- a/base/src/main/java/com/austindroids/austinfeedsme/eventsfilter/EventFilterActivity.java
+++ b/base/src/main/java/com/austindroids/austinfeedsme/eventsfilter/EventFilterActivity.java
@@ -1,8 +1,8 @@
 package com.austindroids.austinfeedsme.eventsfilter;
 
 import android.os.Bundle;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.austindroids.austinfeedsme.R;
 import com.austindroids.austinfeedsme.common.base.BaseActivity;
@@ -10,7 +10,6 @@ import com.austindroids.austinfeedsme.data.Event;
 import com.austindroids.austinfeedsme.data.EventsDataSource;
 import com.austindroids.austinfeedsme.data.EventsRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;

--- a/base/src/main/java/com/austindroids/austinfeedsme/eventsfilter/EventFilterAdapter.java
+++ b/base/src/main/java/com/austindroids/austinfeedsme/eventsfilter/EventFilterAdapter.java
@@ -1,7 +1,7 @@
 package com.austindroids.austinfeedsme.eventsfilter;
 
 import android.content.Context;
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/base/src/main/java/com/austindroids/austinfeedsme/eventsmap/CardPagerAdapter.kt
+++ b/base/src/main/java/com/austindroids/austinfeedsme/eventsmap/CardPagerAdapter.kt
@@ -2,8 +2,8 @@ package com.austindroids.austinfeedsme.eventsmap
 
 import android.content.Intent
 import android.net.Uri
-import android.support.v4.view.PagerAdapter
-import android.support.v7.widget.CardView
+import androidx.viewpager.widget.PagerAdapter
+import androidx.cardview.widget.CardView
 import android.text.method.ScrollingMovementMethod
 import android.view.LayoutInflater
 import android.view.View

--- a/base/src/main/java/com/austindroids/austinfeedsme/eventsmap/EventsMapActivity.kt
+++ b/base/src/main/java/com/austindroids/austinfeedsme/eventsmap/EventsMapActivity.kt
@@ -6,14 +6,14 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.app.ActivityCompat
-import android.support.v4.content.ContextCompat
-import android.support.v4.view.ViewPager
-import android.support.v7.widget.PopupMenu
-import android.support.v7.widget.Toolbar
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.widget.PopupMenu
+import androidx.appcompat.widget.Toolbar
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.viewpager.widget.ViewPager
 import com.austindroids.austinfeedsme.R
 import com.austindroids.austinfeedsme.common.base.BaseActivity
 import com.austindroids.austinfeedsme.common.events.EventsContract
@@ -78,8 +78,6 @@ class EventsMapActivity : BaseActivity(), EventsContract.View, OnMapReadyCallbac
 
             }
         })
-
-
     }
 
     override fun onRequestPermissionsResult(requestCode: Int,
@@ -182,9 +180,6 @@ class EventsMapActivity : BaseActivity(), EventsContract.View, OnMapReadyCallbac
 
     override fun showEvents(events: List<Event>) {
         map.clear()
-
-        cardPagerAdapter = CardPagerAdapter(events)
-        viewPager!!.adapter = cardPagerAdapter
 
         for (event in events) {
             if (event.venue == null || event.foodType == null) {

--- a/base/src/main/res/layout/activity_addeditevent.xml
+++ b/base/src/main/res/layout/activity_addeditevent.xml
@@ -6,69 +6,69 @@
     android:layout_height="match_parent"
     android:padding="16dp">
 
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-    <android.support.design.widget.TextInputEditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/title_add_edit_event_edittext"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/name"/>
 
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-    <android.support.design.widget.TextInputEditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/description_add_edit_event_edittext"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/description"/>
 
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/date_add_edit_event_edittext"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/date"/>
 
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/host_add_edit_event_edittext"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/host"/>
 
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/rsvp_link_add_edit_event_edittext"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/rsvp_link"/>
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/food_type_add_edit_event_edittext"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/rsvp_link"/>
 
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>

--- a/base/src/main/res/layout/activity_event_filter.xml
+++ b/base/src/main/res/layout/activity_event_filter.xml
@@ -7,7 +7,7 @@
     android:fitsSystemWindows="true"
     tools:context=".eventsfilter.EventFilterActivity">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/event_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/base/src/main/res/layout/activity_events.xml
+++ b/base/src/main/res/layout/activity_events.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout android:id="@+id/drawer_layout_events"
+<androidx.drawerlayout.widget.DrawerLayout android:id="@+id/drawer_layout_events"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,24 +9,24 @@
     tools:openDrawer="start"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <android.support.design.widget.CoordinatorLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 android:background="?attr/colorPrimary"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -34,18 +34,18 @@
             android:orientation="vertical"
             android:paddingTop="?attr/actionBarSize">
 
-            <android.support.v4.widget.SwipeRefreshLayout
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
                 android:id="@+id/swipe_refresh_layout_events"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <android.support.v7.widget.RecyclerView
+                <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_view_events"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:divider="@null"
                     android:scrollbars="vertical" />
-            </android.support.v4.widget.SwipeRefreshLayout>
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
             <LinearLayout
                 android:id="@+id/linear_layout_no_events"
@@ -75,11 +75,11 @@
 
         </LinearLayout>
 
-    </android.support.design.widget.CoordinatorLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <include layout="@layout/include_progress_overlay"/>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/navigation_view_events"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -87,4 +87,4 @@
         app:menu="@menu/navigation_items_events"
         app:headerLayout="@layout/nav_header"/>
 
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/base/src/main/res/layout/activity_events_map.xml
+++ b/base/src/main/res/layout/activity_events_map.xml
@@ -4,20 +4,20 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/map_toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <fragment xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -27,7 +27,7 @@
         tools:context=".eventsmap.EventsMapActivity"
         android:name="com.google.android.gms.maps.SupportMapFragment"
         />
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="270dp"

--- a/base/src/main/res/layout/adapter.xml
+++ b/base/src/main/res/layout/adapter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/cardView"
     app:cardUseCompatPadding="true"
@@ -50,4 +50,4 @@
         </LinearLayout>
     </FrameLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/base/src/main/res/layout/fragment_adapter.xml
+++ b/base/src/main/res/layout/fragment_adapter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/cardView"
     app:cardUseCompatPadding="true"
@@ -35,4 +35,4 @@
                 android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Etiam eget ligula eu lectus lobortis condimentum." />
         </LinearLayout>
     </FrameLayout>
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/base/src/main/res/layout/list_item_event.xml
+++ b/base/src/main/res/layout/list_item_event.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -90,4 +90,4 @@
             </RelativeLayout>
         </LinearLayout>
     </LinearLayout>
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/base/src/main/res/layout/list_item_event_filter.xml
+++ b/base/src/main/res/layout/list_item_event_filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -69,4 +69,4 @@
             android:autoLink="web"/>
 
     </LinearLayout>
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/base/src/main/res/menu/menu_events.xml
+++ b/base/src/main/res/menu/menu_events.xml
@@ -7,7 +7,7 @@
         android:title="Search"
         android:icon="@android:drawable/ic_menu_search"
         app:showAsAction="collapseActionView|always"
-        app:actionViewClass="android.support.v7.widget.SearchView" />
+        app:actionViewClass="androidx.appcompat.widget.SearchView" />
     <item
         android:id="@+id/map_filter"
         android:title="@string/menu_filter"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.2.51'
     repositories {
         jcenter()
         google()
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.google.gms:google-services:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.fabric.tools:gradle:1.25.4'
@@ -26,13 +26,13 @@ allprojects {
 ext {
     // SDK and Tools
     minSdkVersion = 21
-    targetSdkVersion = 27
-    compileSdkVersion = 27
-    buildToolsVersion = '27.0.3'
+    targetSdkVersion = 28
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
 
     // App dependencies
-    firebaseVersion = '16.0.1'
-    firestoreVersion = '17.0.2'
+    firebaseVersion = '16.0.4'
+    firestoreVersion = '17.1.3'
     supportLibraryVersion = '27.1.1'
     daggerVersion = "2.15"
     playServicesVersion = "15.0.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 austinfeedsme.properties=../austinfeedsme.properties
 android.enableD8 = true
 android.enableR8 = true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Wed Mar 28 13:08:05 CDT 2018
+#Mon Nov 12 18:42:01 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
-
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
* Migrate to androidx (#65)

* current migration to firestore

* minor clean up

* cleaning up eventbrite datasource, need to make getting events from firestore dry

* further migration work

* more cleaning

* events dont want to load anymore....

* got to call a callback if you got to call a callback

* in the right place too

* its working, need to clean up a few things

* work on using smaller logo for eventbrite events

* merge map optimizations

* keep firestore from sprawling throughout the entire app

* minor cleaning

* minor change in retrofit api

* clean up any events that aren't in the future

* experimenting with how to handling filtering?

* remove unused package

* minor cleaning

* create rx interface for events repository

* temporarily disable proguard on debug builds

* first attempt to migrate to rx repository layer

* this builds locally!

* fix bug in firestore query logic

* minor updates to food type logic

* minor formatting updates

* minor cleanup

* remove duplicate events by id

* minor cleanup

* why didnt refactor rename things correctly?

* woo

* update build.gradle

* further migration to androidx

* fix import

* more cleaning

* cleanup invalid method

* remove code that was used for debugging

* make sure it builds